### PR TITLE
[PR] user service의 회원가입, 로그인 구현

### DIFF
--- a/src/auth/auth-role.decorator.ts
+++ b/src/auth/auth-role.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from 'src/users/entities/users.entity';
+
+export type UserRoles = keyof typeof Role | 'ANY';
+
+export const UserRole = (userRoles: UserRoles[]) =>
+  SetMetadata('userRoles', userRoles);

--- a/src/auth/auth-user.decorator.ts
+++ b/src/auth/auth-user.decorator.ts
@@ -1,0 +1,11 @@
+import { ExecutionContext } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { createParamDecorator } from '@nestjs/common';
+
+export const AuthUser = createParamDecorator(
+  (data: unknown, context: ExecutionContext) => {
+    const ctx = GqlExecutionContext.create(context).getContext();
+    const user = ctx['user'];
+    return user;
+  },
+);

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -1,0 +1,42 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { UserService } from 'src/users/users.service';
+import { UserRoles } from './auth-role.decorator';
+import { JwtService } from '@nestjs/jwt';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly jwtService: JwtService,
+    private readonly userService: UserService,
+  ) {}
+  async canActivate(context: ExecutionContext) {
+    const userRoles = this.reflector.get<UserRoles>(
+      'userRoles',
+      context.getHandler(),
+    );
+    if (!userRoles) {
+      return true;
+    }
+
+    const gqlContext = GqlExecutionContext.create(context).getContext();
+    const token = gqlContext.token;
+
+    if (token) {
+      const decoded = this.jwtService.verify(token.toString());
+      if (typeof decoded === 'object' && decoded.hasOwnProperty('id')) {
+        const { user } = await this.userService.findById(decoded['id']);
+        if (user) {
+          gqlContext['user'] = user;
+          if (userRoles.includes('ANY')) {
+            return true;
+          }
+          return userRoles.includes(user.role);
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
-import { AuthService } from './auth.service';
 import { JwtModule } from '@nestjs/jwt';
 import { AuthGuard } from './auth.guard';
 import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
   imports: [
@@ -18,14 +18,13 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
       }),
     }),
     ConfigService,
+    UsersModule,
   ],
   providers: [
-    AuthService,
     {
       provide: APP_GUARD,
       useClass: AuthGuard,
     },
   ],
-  exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { JwtModule } from '@nestjs/jwt';
+import { AuthGuard } from './auth.guard';
+import { APP_GUARD } from '@nestjs/core';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+
+@Module({
+  imports: [
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get('JWT_SECRET'),
+        signOptions: {
+          expiresIn: `${configService.get('JWT_EXPIRATION_TIME')}d`,
+        },
+      }),
+    }),
+    ConfigService,
+  ],
+  providers: [
+    AuthService,
+    {
+      provide: APP_GUARD,
+      useClass: AuthGuard,
+    },
+  ],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+
+@Injectable()
+export class AuthService {
+  constructor(private readonly jwtService: JwtService) {}
+
+  async sign(userId: number) {
+    return this.jwtService.sign({ id: userId });
+  }
+
+  verify(token: string) {
+    return this.jwtService.verify(token);
+  }
+}

--- a/src/common/dtos/output.dto.ts
+++ b/src/common/dtos/output.dto.ts
@@ -1,0 +1,10 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class OutputDto {
+  @Field((type) => String, { nullable: true })
+  error?: string;
+
+  @Field((type) => Boolean)
+  ok: boolean;
+}

--- a/src/users/dtos/create-account.dto.ts
+++ b/src/users/dtos/create-account.dto.ts
@@ -1,0 +1,13 @@
+import { Field, InputType, ObjectType, PickType } from '@nestjs/graphql';
+import { OutputDto } from 'src/common/dtos/output.dto';
+import { User } from '../entities/users.entity';
+
+@InputType()
+export class CreateAccountInput extends PickType(User, [
+  'email',
+  'password',
+  'role',
+]) {}
+
+@ObjectType()
+export class CreateAccountOutput extends OutputDto {}

--- a/src/users/dtos/login.dto.ts
+++ b/src/users/dtos/login.dto.ts
@@ -1,0 +1,12 @@
+import { Field, InputType, ObjectType, PickType } from '@nestjs/graphql';
+import { OutputDto } from 'src/common/dtos/output.dto';
+import { User } from '../entities/users.entity';
+
+@InputType()
+export class LoginInput extends PickType(User, ['email', 'password']) {}
+
+@ObjectType()
+export class LoginOutput extends OutputDto {
+  @Field((type) => String, { nullable: true })
+  token?: string;
+}

--- a/src/users/dtos/user-profile.dto.ts
+++ b/src/users/dtos/user-profile.dto.ts
@@ -1,0 +1,15 @@
+import { ArgsType, Field, ObjectType } from '@nestjs/graphql';
+import { OutputDto } from 'src/common/dtos/output.dto';
+import { User } from '../entities/users.entity';
+
+@ArgsType()
+export class UserProfileInput {
+  @Field((type) => Number)
+  userId: number;
+}
+
+@ObjectType()
+export class UserProfileOutput extends OutputDto {
+  @Field((type) => User, { nullable: true })
+  user?: User;
+}

--- a/src/users/entities/users.entity.ts
+++ b/src/users/entities/users.entity.ts
@@ -5,12 +5,22 @@ import {
   registerEnumType,
 } from '@nestjs/graphql';
 import { CoreEntity } from 'src/common/entities/core.entity';
-import { Column, Entity, JoinTable, ManyToMany, OneToMany } from 'typeorm';
+import {
+  BeforeInsert,
+  BeforeUpdate,
+  Column,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  OneToMany,
+} from 'typeorm';
 import { IsString, IsEnum, IsEmail } from 'class-validator';
 import { School } from 'src/schools/entities/schools.entity';
 import { UserSchoolManage } from 'src/user-school-manage/entites/user-school-manage.entity';
 import { UserSchoolFollow } from 'src/user-school-follow/entites/user-school-follow.entity';
 import { News } from 'src/news/entites/news.entity';
+import { InternalServerErrorException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
 
 export enum Role {
   MANAGER = 'MANAGER',
@@ -52,4 +62,16 @@ export class User extends CoreEntity {
 
   @OneToMany((type) => News, (news) => news.user)
   writingNews: News[];
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  async hashPassword(): Promise<void> {
+    if (this.password) {
+      try {
+        this.password = await bcrypt.hash(this.password, 10);
+      } catch (e) {
+        throw new InternalServerErrorException();
+      }
+    }
+  }
 }

--- a/src/users/entities/users.entity.ts
+++ b/src/users/entities/users.entity.ts
@@ -74,4 +74,13 @@ export class User extends CoreEntity {
       }
     }
   }
+
+  async checkPassword(aPassword: string): Promise<boolean> {
+    try {
+      const ok = await bcrypt.compare(aPassword, this.password);
+      return ok;
+    } catch (e) {
+      throw new InternalServerErrorException();
+    }
+  }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,4 +1,27 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entities/users.entity';
+import { UserResolver } from './users.resolver';
+import { UserService } from './users.service';
 
-@Module({})
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([User]),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get('JWT_SECRET'),
+        signOptions: {
+          expiresIn: `${configService.get('JWT_EXPIRATION_TIME')}d`,
+        },
+      }),
+    }),
+    ConfigService,
+  ],
+  providers: [UserResolver, UserService],
+  exports: [UserService],
+})
 export class UsersModule {}

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -10,6 +10,7 @@ import {
   CreateAccountInput,
   CreateAccountOutput,
 } from './dtos/create-account.dto';
+import { LoginInput, LoginOutput } from './dtos/login.dto';
 import { User } from './entities/users.entity';
 import { UserService } from './users.service';
 
@@ -22,5 +23,10 @@ export class UserResolver {
     @Args('input') createAccountInput: CreateAccountInput,
   ): Promise<CreateAccountOutput> {
     return this.userService.createAccount(createAccountInput);
+  }
+
+  @Mutation((returns) => LoginOutput)
+  async login(@Args('input') loginInput: LoginInput): Promise<LoginOutput> {
+    return this.userService.login(loginInput);
   }
 }

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -1,0 +1,26 @@
+import {
+  Resolver,
+  Query,
+  Args,
+  Mutation,
+  ResolveField,
+  Parent,
+} from '@nestjs/graphql';
+import {
+  CreateAccountInput,
+  CreateAccountOutput,
+} from './dtos/create-account.dto';
+import { User } from './entities/users.entity';
+import { UserService } from './users.service';
+
+@Resolver((of) => User)
+export class UserResolver {
+  constructor(private readonly userService: UserService) {}
+
+  @Mutation((returns) => CreateAccountOutput)
+  async createAccount(
+    @Args('input') createAccountInput: CreateAccountInput,
+  ): Promise<CreateAccountOutput> {
+    return this.userService.createAccount(createAccountInput);
+  }
+}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -68,4 +68,16 @@ export class UserService {
       };
     }
   }
+
+  async findById(id: number): Promise<UserProfileOutput> {
+    try {
+      const user = await this.users.findOneOrFail({ id });
+      return {
+        ok: true,
+        user,
+      };
+    } catch (error) {
+      return { ok: false, error: 'User Not Found' };
+    }
+  }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  CreateAccountInput,
+  CreateAccountOutput,
+} from './dtos/create-account.dto';
+import { User } from './entities/users.entity';
+
+@Injectable()
+export class UserService {
+  constructor(
+    @InjectRepository(User) private readonly users: Repository<User>,
+  ) {}
+  async createAccount({
+    email,
+    password,
+    role,
+  }: CreateAccountInput): Promise<CreateAccountOutput> {
+    try {
+      const exists = await this.users.findOne({ email });
+      if (exists) {
+        return { ok: false, error: 'There is email already' };
+      }
+      const user = await this.users.save(
+        this.users.create({ email, password, role }),
+      );
+
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: "Couldn't create account" };
+    }
+  }
+}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,16 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { AuthService } from 'src/auth/auth.service';
 import { Repository } from 'typeorm';
 import {
   CreateAccountInput,
   CreateAccountOutput,
 } from './dtos/create-account.dto';
+import { LoginInput, LoginOutput } from './dtos/login.dto';
 import { User } from './entities/users.entity';
 
 @Injectable()
 export class UserService {
   constructor(
     @InjectRepository(User) private readonly users: Repository<User>,
+    private readonly authService: AuthService,
   ) {}
   async createAccount({
     email,
@@ -29,6 +32,39 @@ export class UserService {
       return { ok: true };
     } catch (e) {
       return { ok: false, error: "Couldn't create account" };
+    }
+  }
+
+  async login({ email, password }: LoginInput): Promise<LoginOutput> {
+    try {
+      const user = await this.users.findOne(
+        { email },
+        { select: ['id', 'password'] },
+      );
+      if (!user) {
+        return {
+          ok: false,
+          error: 'User not found',
+        };
+      }
+      const passwordCorrect = await user.checkPassword(password);
+      if (!passwordCorrect) {
+        return {
+          ok: false,
+          error: 'Wrong password',
+        };
+      }
+
+      const token = await this.authService.sign(user.id);
+      return {
+        ok: true,
+        token,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: "Can't log user in.",
+      };
     }
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,19 +1,20 @@
 import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
-import { AuthService } from 'src/auth/auth.service';
 import { Repository } from 'typeorm';
 import {
   CreateAccountInput,
   CreateAccountOutput,
 } from './dtos/create-account.dto';
 import { LoginInput, LoginOutput } from './dtos/login.dto';
+import { UserProfileOutput } from './dtos/user-profile.dto';
 import { User } from './entities/users.entity';
 
 @Injectable()
 export class UserService {
   constructor(
     @InjectRepository(User) private readonly users: Repository<User>,
-    private readonly authService: AuthService,
+    private readonly jwtService: JwtService,
   ) {}
   async createAccount({
     email,
@@ -55,7 +56,7 @@ export class UserService {
         };
       }
 
-      const token = await this.authService.sign(user.id);
+      const token = await this.jwtService.sign({ id: user.id });
       return {
         ok: true,
         token,


### PR DESCRIPTION
- 회원가입 시 password는 단방향 해싱을 한다.
- 로그인을 하면, token을 응답값으로 준다.
- header의 Authorization에 jwt를 넣어서 보낸다.
- nest js의 guard를 이용해 권한 체크를 한다.